### PR TITLE
Add controllers for core entities

### DIFF
--- a/src/main/java/io/github/ahumadamob/plangastos/controller/CuentaFinancieraController.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/controller/CuentaFinancieraController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Cuenta financiera")
 @RestController
-@RequestMapping("/api/v1/cuentas-financieras")
+@RequestMapping("/api/v1/cuenta-financiera")
 @Validated
 public class CuentaFinancieraController {
 

--- a/src/main/java/io/github/ahumadamob/plangastos/controller/DivisaController.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/controller/DivisaController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Divisa")
 @RestController
-@RequestMapping("/api/v1/divisas")
+@RequestMapping("/api/v1/divisa")
 @Validated
 public class DivisaController {
 

--- a/src/main/java/io/github/ahumadamob/plangastos/controller/PartidaPlanificadaController.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/controller/PartidaPlanificadaController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Partida planificada")
 @RestController
-@RequestMapping("/api/v1/partidas-planificadas")
+@RequestMapping("/api/v1/partida-planificada")
 @Validated
 public class PartidaPlanificadaController {
 

--- a/src/main/java/io/github/ahumadamob/plangastos/controller/PlanPresupuestarioController.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/controller/PlanPresupuestarioController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Plan presupuestario")
 @RestController
-@RequestMapping("/api/v1/planes-presupuestarios")
+@RequestMapping("/api/v1/plan-presupuestario")
 @Validated
 public class PlanPresupuestarioController {
 

--- a/src/main/java/io/github/ahumadamob/plangastos/controller/PresupuestoController.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/controller/PresupuestoController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Presupuesto")
 @RestController
-@RequestMapping("/api/v1/presupuestos")
+@RequestMapping("/api/v1/presupuesto")
 @Validated
 public class PresupuestoController {
 

--- a/src/main/java/io/github/ahumadamob/plangastos/controller/RubroController.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/controller/RubroController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Rubro")
 @RestController
-@RequestMapping("/api/v1/rubros")
+@RequestMapping("/api/v1/rubro")
 @Validated
 public class RubroController {
 

--- a/src/main/java/io/github/ahumadamob/plangastos/controller/TransaccionController.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/controller/TransaccionController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Transacción")
 @RestController
-@RequestMapping("/api/v1/transacciones")
+@RequestMapping("/api/v1/transaccion")
 @Validated
 public class TransaccionController {
 

--- a/src/main/java/io/github/ahumadamob/plangastos/controller/UsuarioController.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/controller/UsuarioController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Usuario")
 @RestController
-@RequestMapping("/api/v1/usuarios")
+@RequestMapping("/api/v1/usuario")
 @Validated
 public class UsuarioController {
 


### PR DESCRIPTION
## Summary
- add REST controllers for financial, budgeting, and user domain entities
- expose CRUD endpoints using existing services and mappers
- standardize responses with ApiResponseFactory

## Testing
- mvn -q test *(fails: dependency download blocked by 403 from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f45c34b78832fb52ffe74d605db46)