### PR TITLE
Lookup related entities by id in request mappers

### DIFF
--- a/src/main/java/io/github/ahumadamob/plangastos/controller/CuentaFinancieraController.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/controller/CuentaFinancieraController.java
@@ -26,15 +26,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class CuentaFinancieraController {
 
     private final CuentaFinancieraService service;
+    private final CuentaFinancieraMapper mapper;
 
-    public CuentaFinancieraController(CuentaFinancieraService service) {
+    public CuentaFinancieraController(CuentaFinancieraService service, CuentaFinancieraMapper mapper) {
         this.service = service;
+        this.mapper = mapper;
     }
 
     @GetMapping
     public ResponseEntity<ApiResponseSuccessDto<List<CuentaFinancieraResponseDto>>> getAll() {
         List<CuentaFinancieraResponseDto> data = service.getAll().stream()
-                .map(CuentaFinancieraMapper::entityToResponse)
+                .map(mapper::entityToResponse)
                 .toList();
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Listado de cuentas financieras"));
     }
@@ -42,23 +44,23 @@ public class CuentaFinancieraController {
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponseSuccessDto<CuentaFinancieraResponseDto>> getById(
             @PathVariable Long id) {
-        CuentaFinancieraResponseDto data = CuentaFinancieraMapper.entityToResponse(service.getById(id));
+        CuentaFinancieraResponseDto data = mapper.entityToResponse(service.getById(id));
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Detalle de cuenta financiera"));
     }
 
     @PostMapping
     public ResponseEntity<ApiResponseSuccessDto<CuentaFinancieraResponseDto>> create(
             @RequestBody CuentaFinancieraRequestDto request) {
-        CuentaFinancieraResponseDto data = CuentaFinancieraMapper.entityToResponse(
-                service.create(CuentaFinancieraMapper.requestToEntity(request)));
+        CuentaFinancieraResponseDto data = mapper.entityToResponse(
+                service.create(mapper.requestToEntity(request)));
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Cuenta financiera creada"));
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<ApiResponseSuccessDto<CuentaFinancieraResponseDto>> update(
             @PathVariable Long id, @RequestBody CuentaFinancieraRequestDto request) {
-        CuentaFinancieraResponseDto data = CuentaFinancieraMapper.entityToResponse(
-                service.update(id, CuentaFinancieraMapper.requestToEntity(request)));
+        CuentaFinancieraResponseDto data = mapper.entityToResponse(
+                service.update(id, mapper.requestToEntity(request)));
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Cuenta financiera actualizada"));
     }
 

--- a/src/main/java/io/github/ahumadamob/plangastos/controller/PartidaPlanificadaController.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/controller/PartidaPlanificadaController.java
@@ -26,15 +26,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class PartidaPlanificadaController {
 
     private final PartidaPlanificadaService service;
+    private final PartidaPlanificadaMapper mapper;
 
-    public PartidaPlanificadaController(PartidaPlanificadaService service) {
+    public PartidaPlanificadaController(PartidaPlanificadaService service, PartidaPlanificadaMapper mapper) {
         this.service = service;
+        this.mapper = mapper;
     }
 
     @GetMapping
     public ResponseEntity<ApiResponseSuccessDto<List<PartidaPlanificadaResponseDto>>> getAll() {
         List<PartidaPlanificadaResponseDto> data = service.getAll().stream()
-                .map(PartidaPlanificadaMapper::entityToResponse)
+                .map(mapper::entityToResponse)
                 .toList();
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Listado de partidas planificadas"));
     }
@@ -42,23 +44,23 @@ public class PartidaPlanificadaController {
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponseSuccessDto<PartidaPlanificadaResponseDto>> getById(
             @PathVariable Long id) {
-        PartidaPlanificadaResponseDto data = PartidaPlanificadaMapper.entityToResponse(service.getById(id));
+        PartidaPlanificadaResponseDto data = mapper.entityToResponse(service.getById(id));
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Detalle de partida planificada"));
     }
 
     @PostMapping
     public ResponseEntity<ApiResponseSuccessDto<PartidaPlanificadaResponseDto>> create(
             @RequestBody PartidaPlanificadaRequestDto request) {
-        PartidaPlanificadaResponseDto data = PartidaPlanificadaMapper.entityToResponse(
-                service.create(PartidaPlanificadaMapper.requestToEntity(request)));
+        PartidaPlanificadaResponseDto data = mapper.entityToResponse(
+                service.create(mapper.requestToEntity(request)));
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Partida planificada creada"));
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<ApiResponseSuccessDto<PartidaPlanificadaResponseDto>> update(
             @PathVariable Long id, @RequestBody PartidaPlanificadaRequestDto request) {
-        PartidaPlanificadaResponseDto data = PartidaPlanificadaMapper.entityToResponse(
-                service.update(id, PartidaPlanificadaMapper.requestToEntity(request)));
+        PartidaPlanificadaResponseDto data = mapper.entityToResponse(
+                service.update(id, mapper.requestToEntity(request)));
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Partida planificada actualizada"));
     }
 

--- a/src/main/java/io/github/ahumadamob/plangastos/controller/PlanPresupuestarioController.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/controller/PlanPresupuestarioController.java
@@ -26,15 +26,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class PlanPresupuestarioController {
 
     private final PlanPresupuestarioService service;
+    private final PlanPresupuestarioMapper mapper;
 
-    public PlanPresupuestarioController(PlanPresupuestarioService service) {
+    public PlanPresupuestarioController(PlanPresupuestarioService service, PlanPresupuestarioMapper mapper) {
         this.service = service;
+        this.mapper = mapper;
     }
 
     @GetMapping
     public ResponseEntity<ApiResponseSuccessDto<List<PlanPresupuestarioResponseDto>>> getAll() {
         List<PlanPresupuestarioResponseDto> data = service.getAll().stream()
-                .map(PlanPresupuestarioMapper::entityToResponse)
+                .map(mapper::entityToResponse)
                 .toList();
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Listado de planes presupuestarios"));
     }
@@ -42,23 +44,23 @@ public class PlanPresupuestarioController {
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponseSuccessDto<PlanPresupuestarioResponseDto>> getById(
             @PathVariable Long id) {
-        PlanPresupuestarioResponseDto data = PlanPresupuestarioMapper.entityToResponse(service.getById(id));
+        PlanPresupuestarioResponseDto data = mapper.entityToResponse(service.getById(id));
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Detalle de plan presupuestario"));
     }
 
     @PostMapping
     public ResponseEntity<ApiResponseSuccessDto<PlanPresupuestarioResponseDto>> create(
             @RequestBody PlanPresupuestarioRequestDto request) {
-        PlanPresupuestarioResponseDto data = PlanPresupuestarioMapper.entityToResponse(
-                service.create(PlanPresupuestarioMapper.requestToEntity(request)));
+        PlanPresupuestarioResponseDto data = mapper.entityToResponse(
+                service.create(mapper.requestToEntity(request)));
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Plan presupuestario creado"));
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<ApiResponseSuccessDto<PlanPresupuestarioResponseDto>> update(
             @PathVariable Long id, @RequestBody PlanPresupuestarioRequestDto request) {
-        PlanPresupuestarioResponseDto data = PlanPresupuestarioMapper.entityToResponse(
-                service.update(id, PlanPresupuestarioMapper.requestToEntity(request)));
+        PlanPresupuestarioResponseDto data = mapper.entityToResponse(
+                service.update(id, mapper.requestToEntity(request)));
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Plan presupuestario actualizado"));
     }
 

--- a/src/main/java/io/github/ahumadamob/plangastos/controller/PresupuestoController.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/controller/PresupuestoController.java
@@ -26,38 +26,40 @@ import org.springframework.web.bind.annotation.RestController;
 public class PresupuestoController {
 
     private final PresupuestoService service;
+    private final PresupuestoMapper mapper;
 
-    public PresupuestoController(PresupuestoService service) {
+    public PresupuestoController(PresupuestoService service, PresupuestoMapper mapper) {
         this.service = service;
+        this.mapper = mapper;
     }
 
     @GetMapping
     public ResponseEntity<ApiResponseSuccessDto<List<PresupuestoResponseDto>>> getAll() {
         List<PresupuestoResponseDto> data = service.getAll().stream()
-                .map(PresupuestoMapper::entityToResponse)
+                .map(mapper::entityToResponse)
                 .toList();
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Listado de presupuestos"));
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponseSuccessDto<PresupuestoResponseDto>> getById(@PathVariable Long id) {
-        PresupuestoResponseDto data = PresupuestoMapper.entityToResponse(service.getById(id));
+        PresupuestoResponseDto data = mapper.entityToResponse(service.getById(id));
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Detalle de presupuesto"));
     }
 
     @PostMapping
     public ResponseEntity<ApiResponseSuccessDto<PresupuestoResponseDto>> create(
             @RequestBody PresupuestoRequestDto request) {
-        PresupuestoResponseDto data = PresupuestoMapper.entityToResponse(
-                service.create(PresupuestoMapper.requestToEntity(request)));
+        PresupuestoResponseDto data = mapper.entityToResponse(
+                service.create(mapper.requestToEntity(request)));
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Presupuesto creado"));
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<ApiResponseSuccessDto<PresupuestoResponseDto>> update(
             @PathVariable Long id, @RequestBody PresupuestoRequestDto request) {
-        PresupuestoResponseDto data = PresupuestoMapper.entityToResponse(
-                service.update(id, PresupuestoMapper.requestToEntity(request)));
+        PresupuestoResponseDto data = mapper.entityToResponse(
+                service.update(id, mapper.requestToEntity(request)));
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Presupuesto actualizado"));
     }
 

--- a/src/main/java/io/github/ahumadamob/plangastos/controller/RubroController.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/controller/RubroController.java
@@ -26,38 +26,40 @@ import org.springframework.web.bind.annotation.RestController;
 public class RubroController {
 
     private final RubroService service;
+    private final RubroMapper mapper;
 
-    public RubroController(RubroService service) {
+    public RubroController(RubroService service, RubroMapper mapper) {
         this.service = service;
+        this.mapper = mapper;
     }
 
     @GetMapping
     public ResponseEntity<ApiResponseSuccessDto<List<RubroResponseDto>>> getAll() {
         List<RubroResponseDto> data = service.getAll().stream()
-                .map(RubroMapper::entityToResponse)
+                .map(mapper::entityToResponse)
                 .toList();
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Listado de rubros"));
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponseSuccessDto<RubroResponseDto>> getById(@PathVariable Long id) {
-        RubroResponseDto data = RubroMapper.entityToResponse(service.getById(id));
+        RubroResponseDto data = mapper.entityToResponse(service.getById(id));
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Detalle de rubro"));
     }
 
     @PostMapping
     public ResponseEntity<ApiResponseSuccessDto<RubroResponseDto>> create(
             @RequestBody RubroRequestDto request) {
-        RubroResponseDto data = RubroMapper.entityToResponse(
-                service.create(RubroMapper.requestToEntity(request)));
+        RubroResponseDto data = mapper.entityToResponse(
+                service.create(mapper.requestToEntity(request)));
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Rubro creado"));
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<ApiResponseSuccessDto<RubroResponseDto>> update(
             @PathVariable Long id, @RequestBody RubroRequestDto request) {
-        RubroResponseDto data = RubroMapper.entityToResponse(
-                service.update(id, RubroMapper.requestToEntity(request)));
+        RubroResponseDto data = mapper.entityToResponse(
+                service.update(id, mapper.requestToEntity(request)));
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Rubro actualizado"));
     }
 

--- a/src/main/java/io/github/ahumadamob/plangastos/controller/TransaccionController.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/controller/TransaccionController.java
@@ -26,38 +26,40 @@ import org.springframework.web.bind.annotation.RestController;
 public class TransaccionController {
 
     private final TransaccionService service;
+    private final TransaccionMapper mapper;
 
-    public TransaccionController(TransaccionService service) {
+    public TransaccionController(TransaccionService service, TransaccionMapper mapper) {
         this.service = service;
+        this.mapper = mapper;
     }
 
     @GetMapping
     public ResponseEntity<ApiResponseSuccessDto<List<TransaccionResponseDto>>> getAll() {
         List<TransaccionResponseDto> data = service.getAll().stream()
-                .map(TransaccionMapper::entityToResponse)
+                .map(mapper::entityToResponse)
                 .toList();
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Listado de transacciones"));
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponseSuccessDto<TransaccionResponseDto>> getById(@PathVariable Long id) {
-        TransaccionResponseDto data = TransaccionMapper.entityToResponse(service.getById(id));
+        TransaccionResponseDto data = mapper.entityToResponse(service.getById(id));
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Detalle de transacción"));
     }
 
     @PostMapping
     public ResponseEntity<ApiResponseSuccessDto<TransaccionResponseDto>> create(
             @RequestBody TransaccionRequestDto request) {
-        TransaccionResponseDto data = TransaccionMapper.entityToResponse(
-                service.create(TransaccionMapper.requestToEntity(request)));
+        TransaccionResponseDto data = mapper.entityToResponse(
+                service.create(mapper.requestToEntity(request)));
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Transacción creada"));
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<ApiResponseSuccessDto<TransaccionResponseDto>> update(
             @PathVariable Long id, @RequestBody TransaccionRequestDto request) {
-        TransaccionResponseDto data = TransaccionMapper.entityToResponse(
-                service.update(id, TransaccionMapper.requestToEntity(request)));
+        TransaccionResponseDto data = mapper.entityToResponse(
+                service.update(id, mapper.requestToEntity(request)));
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Transacción actualizada"));
     }
 

--- a/src/main/java/io/github/ahumadamob/plangastos/dto/CuentaFinancieraRequestDto.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/dto/CuentaFinancieraRequestDto.java
@@ -1,9 +1,7 @@
 package io.github.ahumadamob.plangastos.dto;
 import java.math.BigDecimal;
 
-import io.github.ahumadamob.plangastos.entity.Divisa;
 import io.github.ahumadamob.plangastos.entity.TipoCuenta;
-import io.github.ahumadamob.plangastos.entity.Usuario;
 
 public class CuentaFinancieraRequestDto {
 

--- a/src/main/java/io/github/ahumadamob/plangastos/dto/PartidaPlanificadaRequestDto.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/dto/PartidaPlanificadaRequestDto.java
@@ -2,9 +2,6 @@ package io.github.ahumadamob.plangastos.dto;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
-import io.github.ahumadamob.plangastos.entity.Presupuesto;
-import io.github.ahumadamob.plangastos.entity.Rubro;
-
 public class PartidaPlanificadaRequestDto {
 
     private Long presupuesto_id;

--- a/src/main/java/io/github/ahumadamob/plangastos/dto/PlanPresupuestarioRequestDto.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/dto/PlanPresupuestarioRequestDto.java
@@ -1,7 +1,4 @@
 package io.github.ahumadamob.plangastos.dto;
-import io.github.ahumadamob.plangastos.entity.Divisa;
-import io.github.ahumadamob.plangastos.entity.Usuario;
-
 public class PlanPresupuestarioRequestDto {
 
     private Long usuario_id;

--- a/src/main/java/io/github/ahumadamob/plangastos/dto/PresupuestoRequestDto.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/dto/PresupuestoRequestDto.java
@@ -1,9 +1,6 @@
 package io.github.ahumadamob.plangastos.dto;
 import java.time.LocalDate;
 
-import io.github.ahumadamob.plangastos.entity.PlanPresupuestario;
-import io.github.ahumadamob.plangastos.entity.Presupuesto;
-
 public class PresupuestoRequestDto {
 
     private Long planPresupuestario_id;
@@ -11,7 +8,7 @@ public class PresupuestoRequestDto {
     private String codigo;
     private LocalDate fechaDesde;
     private LocalDate fechaHasta;
-    private Presupuesto presupuestoOrigen;
+    private Long presupuestoOrigen_id;
     
 	public Long getPlanPresupuestario_id() {
 		return planPresupuestario_id;
@@ -43,12 +40,12 @@ public class PresupuestoRequestDto {
 	public void setFechaHasta(LocalDate fechaHasta) {
 		this.fechaHasta = fechaHasta;
 	}
-	public Presupuesto getPresupuestoOrigen() {
-		return presupuestoOrigen;
-	}
-	public void setPresupuestoOrigen(Presupuesto presupuestoOrigen) {
-		this.presupuestoOrigen = presupuestoOrigen;
-	}
+        public Long getPresupuestoOrigen_id() {
+                return presupuestoOrigen_id;
+        }
+        public void setPresupuestoOrigen_id(Long presupuestoOrigen_id) {
+                this.presupuestoOrigen_id = presupuestoOrigen_id;
+        }
 
     
 }

--- a/src/main/java/io/github/ahumadamob/plangastos/dto/RubroRequestDto.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/dto/RubroRequestDto.java
@@ -1,8 +1,4 @@
 package io.github.ahumadamob.plangastos.dto;
-import io.github.ahumadamob.plangastos.entity.NaturalezaMovimiento;
-import io.github.ahumadamob.plangastos.entity.Rubro;
-import io.github.ahumadamob.plangastos.entity.Usuario;
-
 public class RubroRequestDto {
 
     private Long usuario_id;

--- a/src/main/java/io/github/ahumadamob/plangastos/dto/TransaccionRequestDto.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/dto/TransaccionRequestDto.java
@@ -2,11 +2,6 @@ package io.github.ahumadamob.plangastos.dto;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
-import io.github.ahumadamob.plangastos.entity.CuentaFinanciera;
-import io.github.ahumadamob.plangastos.entity.PartidaPlanificada;
-import io.github.ahumadamob.plangastos.entity.Presupuesto;
-import io.github.ahumadamob.plangastos.entity.Rubro;
-
 public class TransaccionRequestDto {
 
     private Long presupuesto_id;

--- a/src/main/java/io/github/ahumadamob/plangastos/mapper/CuentaFinancieraMapper.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/mapper/CuentaFinancieraMapper.java
@@ -1,19 +1,25 @@
 package io.github.ahumadamob.plangastos.mapper;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 import io.github.ahumadamob.plangastos.dto.CuentaFinancieraRequestDto;
 import io.github.ahumadamob.plangastos.dto.CuentaFinancieraResponseDto;
 import io.github.ahumadamob.plangastos.entity.CuentaFinanciera;
-import io.github.ahumadamob.plangastos.service.CuentaFinancieraService;
-import io.github.ahumadamob.plangastos.service.DivisaService;
-import io.github.ahumadamob.plangastos.service.UsuarioService;
 
+@Component
 public class CuentaFinancieraMapper {
-	
-    public static CuentaFinanciera requestToEntity(CuentaFinancieraRequestDto request) {
+
+    private final MapperHelper mapperHelper;
+
+    public CuentaFinancieraMapper(MapperHelper mapperHelper) {
+        this.mapperHelper = mapperHelper;
+    }
+
+    public CuentaFinanciera requestToEntity(CuentaFinancieraRequestDto request) {
         CuentaFinanciera cuentaFinanciera = new CuentaFinanciera();
 
+        cuentaFinanciera.setUsuario(mapperHelper.getUsuario(request.getUsuario_id()));
+        cuentaFinanciera.setDivisa(mapperHelper.getDivisa(request.getDivisa_id()));
         cuentaFinanciera.setNombre(request.getNombre());
         cuentaFinanciera.setTipo(request.getTipo());
         cuentaFinanciera.setSaldoInicial(request.getSaldoInicial());
@@ -21,7 +27,7 @@ public class CuentaFinancieraMapper {
         return cuentaFinanciera;
     }
 
-    public static CuentaFinancieraResponseDto entityToResponse(CuentaFinanciera cuentaFinanciera) {
+    public CuentaFinancieraResponseDto entityToResponse(CuentaFinanciera cuentaFinanciera) {
         CuentaFinancieraResponseDto response = new CuentaFinancieraResponseDto();
         response.setId(cuentaFinanciera.getId());
         response.setUsuario(cuentaFinanciera.getUsuario());

--- a/src/main/java/io/github/ahumadamob/plangastos/mapper/MapperHelper.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/mapper/MapperHelper.java
@@ -1,0 +1,101 @@
+package io.github.ahumadamob.plangastos.mapper;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Component;
+
+import io.github.ahumadamob.plangastos.entity.CuentaFinanciera;
+import io.github.ahumadamob.plangastos.entity.Divisa;
+import io.github.ahumadamob.plangastos.entity.NaturalezaMovimiento;
+import io.github.ahumadamob.plangastos.entity.PartidaPlanificada;
+import io.github.ahumadamob.plangastos.entity.PlanPresupuestario;
+import io.github.ahumadamob.plangastos.entity.Presupuesto;
+import io.github.ahumadamob.plangastos.entity.Rubro;
+import io.github.ahumadamob.plangastos.entity.Usuario;
+import io.github.ahumadamob.plangastos.exception.ResourceNotFoundException;
+import io.github.ahumadamob.plangastos.repository.CuentaFinancieraRepository;
+import io.github.ahumadamob.plangastos.repository.DivisaRepository;
+import io.github.ahumadamob.plangastos.repository.PartidaPlanificadaRepository;
+import io.github.ahumadamob.plangastos.repository.PlanPresupuestarioRepository;
+import io.github.ahumadamob.plangastos.repository.PresupuestoRepository;
+import io.github.ahumadamob.plangastos.repository.RubroRepository;
+import io.github.ahumadamob.plangastos.repository.UsuarioRepository;
+
+@Component
+public class MapperHelper {
+
+    private final UsuarioRepository usuarioRepository;
+    private final DivisaRepository divisaRepository;
+    private final PlanPresupuestarioRepository planPresupuestarioRepository;
+    private final PresupuestoRepository presupuestoRepository;
+    private final RubroRepository rubroRepository;
+    private final CuentaFinancieraRepository cuentaFinancieraRepository;
+    private final PartidaPlanificadaRepository partidaPlanificadaRepository;
+
+    public MapperHelper(
+            UsuarioRepository usuarioRepository,
+            DivisaRepository divisaRepository,
+            PlanPresupuestarioRepository planPresupuestarioRepository,
+            PresupuestoRepository presupuestoRepository,
+            RubroRepository rubroRepository,
+            CuentaFinancieraRepository cuentaFinancieraRepository,
+            PartidaPlanificadaRepository partidaPlanificadaRepository) {
+        this.usuarioRepository = usuarioRepository;
+        this.divisaRepository = divisaRepository;
+        this.planPresupuestarioRepository = planPresupuestarioRepository;
+        this.presupuestoRepository = presupuestoRepository;
+        this.rubroRepository = rubroRepository;
+        this.cuentaFinancieraRepository = cuentaFinancieraRepository;
+        this.partidaPlanificadaRepository = partidaPlanificadaRepository;
+    }
+
+    public Usuario getUsuario(Long usuarioId) {
+        return findOrThrow(usuarioRepository, usuarioId, "Usuario");
+    }
+
+    public Divisa getDivisa(Long divisaId) {
+        return findOrThrow(divisaRepository, divisaId, "Divisa");
+    }
+
+    public PlanPresupuestario getPlanPresupuestario(Long planId) {
+        return findOrThrow(planPresupuestarioRepository, planId, "Plan presupuestario");
+    }
+
+    public Presupuesto getPresupuesto(Long presupuestoId) {
+        return findOrThrow(presupuestoRepository, presupuestoId, "Presupuesto");
+    }
+
+    public Rubro getRubro(Long rubroId) {
+        return findOrThrow(rubroRepository, rubroId, "Rubro");
+    }
+
+    public CuentaFinanciera getCuentaFinanciera(Long cuentaFinancieraId) {
+        return findOrThrow(cuentaFinancieraRepository, cuentaFinancieraId, "Cuenta financiera");
+    }
+
+    public PartidaPlanificada getPartidaPlanificada(Long partidaPlanificadaId) {
+        return findOrThrow(partidaPlanificadaRepository, partidaPlanificadaId, "Partida planificada");
+    }
+
+    public NaturalezaMovimiento getNaturalezaMovimiento(Long naturalezaId) {
+        if (naturalezaId == null) {
+            return null;
+        }
+
+        NaturalezaMovimiento[] valores = NaturalezaMovimiento.values();
+        if (naturalezaId < 0 || naturalezaId >= valores.length) {
+            throw new ResourceNotFoundException(
+                    "Naturaleza de movimiento no encontrada con id " + naturalezaId);
+        }
+
+        return valores[naturalezaId.intValue()];
+    }
+
+    private <T> T findOrThrow(JpaRepository<T, Long> repository, Long id, String resourceName) {
+        if (id == null) {
+            return null;
+        }
+        return repository
+                .findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(resourceName + " no encontrado con id " + id));
+    }
+}

--- a/src/main/java/io/github/ahumadamob/plangastos/mapper/PartidaPlanificadaMapper.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/mapper/PartidaPlanificadaMapper.java
@@ -1,22 +1,31 @@
 package io.github.ahumadamob.plangastos.mapper;
 
+import org.springframework.stereotype.Component;
+
 import io.github.ahumadamob.plangastos.dto.PartidaPlanificadaRequestDto;
 import io.github.ahumadamob.plangastos.dto.PartidaPlanificadaResponseDto;
 import io.github.ahumadamob.plangastos.entity.PartidaPlanificada;
 
+@Component
 public class PartidaPlanificadaMapper {
 
-    public static PartidaPlanificada requestToEntity(PartidaPlanificadaRequestDto request) {
+    private final MapperHelper mapperHelper;
+
+    public PartidaPlanificadaMapper(MapperHelper mapperHelper) {
+        this.mapperHelper = mapperHelper;
+    }
+
+    public PartidaPlanificada requestToEntity(PartidaPlanificadaRequestDto request) {
         PartidaPlanificada partida = new PartidaPlanificada();
-        partida.setPresupuesto(request.getPresupuesto());
-        partida.setRubro(request.getRubro());
+        partida.setPresupuesto(mapperHelper.getPresupuesto(request.getPresupuesto_id()));
+        partida.setRubro(mapperHelper.getRubro(request.getRubro_id()));
         partida.setDescripcion(request.getDescripcion());
         partida.setMontoComprometido(request.getMontoComprometido());
         partida.setFechaObjetivo(request.getFechaObjetivo());
         return partida;
     }
 
-    public static PartidaPlanificadaResponseDto entityToResponse(PartidaPlanificada partida) {
+    public PartidaPlanificadaResponseDto entityToResponse(PartidaPlanificada partida) {
         PartidaPlanificadaResponseDto response = new PartidaPlanificadaResponseDto();
         response.setId(partida.getId());
         response.setPresupuesto(partida.getPresupuesto());

--- a/src/main/java/io/github/ahumadamob/plangastos/mapper/PlanPresupuestarioMapper.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/mapper/PlanPresupuestarioMapper.java
@@ -1,22 +1,31 @@
 package io.github.ahumadamob.plangastos.mapper;
 
+import org.springframework.stereotype.Component;
+
 import io.github.ahumadamob.plangastos.dto.PlanPresupuestarioRequestDto;
 import io.github.ahumadamob.plangastos.dto.PlanPresupuestarioResponseDto;
 import io.github.ahumadamob.plangastos.entity.PlanPresupuestario;
 
+@Component
 public class PlanPresupuestarioMapper {
 
-    public static PlanPresupuestario requestToEntity(PlanPresupuestarioRequestDto request) {
+    private final MapperHelper mapperHelper;
+
+    public PlanPresupuestarioMapper(MapperHelper mapperHelper) {
+        this.mapperHelper = mapperHelper;
+    }
+
+    public PlanPresupuestario requestToEntity(PlanPresupuestarioRequestDto request) {
         PlanPresupuestario plan = new PlanPresupuestario();
-        plan.setUsuario(request.getUsuario());
-        plan.setDivisa(request.getDivisa());
+        plan.setUsuario(mapperHelper.getUsuario(request.getUsuario_id()));
+        plan.setDivisa(mapperHelper.getDivisa(request.getDivisa_id()));
         plan.setNombre(request.getNombre());
         plan.setDescripcion(request.getDescripcion());
         plan.setActivo(request.getActivo());
         return plan;
     }
 
-    public static PlanPresupuestarioResponseDto entityToResponse(PlanPresupuestario plan) {
+    public PlanPresupuestarioResponseDto entityToResponse(PlanPresupuestario plan) {
         PlanPresupuestarioResponseDto response = new PlanPresupuestarioResponseDto();
         response.setId(plan.getId());
         response.setUsuario(plan.getUsuario());

--- a/src/main/java/io/github/ahumadamob/plangastos/mapper/PresupuestoMapper.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/mapper/PresupuestoMapper.java
@@ -1,23 +1,32 @@
 package io.github.ahumadamob.plangastos.mapper;
 
+import org.springframework.stereotype.Component;
+
 import io.github.ahumadamob.plangastos.dto.PresupuestoRequestDto;
 import io.github.ahumadamob.plangastos.dto.PresupuestoResponseDto;
 import io.github.ahumadamob.plangastos.entity.Presupuesto;
 
+@Component
 public class PresupuestoMapper {
 
-    public static Presupuesto requestToEntity(PresupuestoRequestDto request) {
+    private final MapperHelper mapperHelper;
+
+    public PresupuestoMapper(MapperHelper mapperHelper) {
+        this.mapperHelper = mapperHelper;
+    }
+
+    public Presupuesto requestToEntity(PresupuestoRequestDto request) {
         Presupuesto presupuesto = new Presupuesto();
-        presupuesto.setPlan(request.getPlan());
+        presupuesto.setPlan(mapperHelper.getPlanPresupuestario(request.getPlanPresupuestario_id()));
         presupuesto.setNombre(request.getNombre());
         presupuesto.setCodigo(request.getCodigo());
         presupuesto.setFechaDesde(request.getFechaDesde());
         presupuesto.setFechaHasta(request.getFechaHasta());
-        presupuesto.setPresupuestoOrigen(request.getPresupuestoOrigen());
+        presupuesto.setPresupuestoOrigen(mapperHelper.getPresupuesto(request.getPresupuestoOrigen_id()));
         return presupuesto;
     }
 
-    public static PresupuestoResponseDto entityToResponse(Presupuesto presupuesto) {
+    public PresupuestoResponseDto entityToResponse(Presupuesto presupuesto) {
         PresupuestoResponseDto response = new PresupuestoResponseDto();
         response.setId(presupuesto.getId());
         response.setPlan(presupuesto.getPlan());

--- a/src/main/java/io/github/ahumadamob/plangastos/mapper/RubroMapper.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/mapper/RubroMapper.java
@@ -1,22 +1,31 @@
 package io.github.ahumadamob.plangastos.mapper;
 
+import org.springframework.stereotype.Component;
+
 import io.github.ahumadamob.plangastos.dto.RubroRequestDto;
 import io.github.ahumadamob.plangastos.dto.RubroResponseDto;
 import io.github.ahumadamob.plangastos.entity.Rubro;
 
+@Component
 public class RubroMapper {
 
-    public static Rubro requestToEntity(RubroRequestDto request) {
+    private final MapperHelper mapperHelper;
+
+    public RubroMapper(MapperHelper mapperHelper) {
+        this.mapperHelper = mapperHelper;
+    }
+
+    public Rubro requestToEntity(RubroRequestDto request) {
         Rubro rubro = new Rubro();
-        rubro.setUsuario(request.getUsuario());
-        rubro.setNaturaleza(request.getNaturaleza());
+        rubro.setUsuario(mapperHelper.getUsuario(request.getUsuario_id()));
+        rubro.setNaturaleza(mapperHelper.getNaturalezaMovimiento(request.getNaturalezaMovimiento_id()));
         rubro.setNombre(request.getNombre());
-        rubro.setParent(request.getParent());
+        rubro.setParent(mapperHelper.getRubro(request.getRubro_id()));
         rubro.setActivo(request.getActivo());
         return rubro;
     }
 
-    public static RubroResponseDto entityToResponse(Rubro rubro) {
+    public RubroResponseDto entityToResponse(Rubro rubro) {
         RubroResponseDto response = new RubroResponseDto();
         response.setId(rubro.getId());
         response.setUsuario(rubro.getUsuario());

--- a/src/main/java/io/github/ahumadamob/plangastos/mapper/TransaccionMapper.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/mapper/TransaccionMapper.java
@@ -1,25 +1,34 @@
 package io.github.ahumadamob.plangastos.mapper;
 
+import org.springframework.stereotype.Component;
+
 import io.github.ahumadamob.plangastos.dto.TransaccionRequestDto;
 import io.github.ahumadamob.plangastos.dto.TransaccionResponseDto;
 import io.github.ahumadamob.plangastos.entity.Transaccion;
 
+@Component
 public class TransaccionMapper {
 
-    public static Transaccion requestToEntity(TransaccionRequestDto request) {
+    private final MapperHelper mapperHelper;
+
+    public TransaccionMapper(MapperHelper mapperHelper) {
+        this.mapperHelper = mapperHelper;
+    }
+
+    public Transaccion requestToEntity(TransaccionRequestDto request) {
         Transaccion transaccion = new Transaccion();
-        transaccion.setPresupuesto(request.getPresupuesto());
-        transaccion.setRubro(request.getRubro());
+        transaccion.setPresupuesto(mapperHelper.getPresupuesto(request.getPresupuesto_id()));
+        transaccion.setRubro(mapperHelper.getRubro(request.getRubro_id()));
         transaccion.setDescripcion(request.getDescripcion());
-        transaccion.setCuenta(request.getCuenta());
+        transaccion.setCuenta(mapperHelper.getCuentaFinanciera(request.getCuentaFinanciera_id()));
         transaccion.setFecha(request.getFecha());
         transaccion.setMonto(request.getMonto());
         transaccion.setReferenciaExterna(request.getReferenciaExterna());
-        transaccion.setPartidaPlanificada(request.getPartidaPlanificada());
+        transaccion.setPartidaPlanificada(mapperHelper.getPartidaPlanificada(request.getPartidaPlanificada_id()));
         return transaccion;
     }
 
-    public static TransaccionResponseDto entityToResponse(Transaccion transaccion) {
+    public TransaccionResponseDto entityToResponse(Transaccion transaccion) {
         TransaccionResponseDto response = new TransaccionResponseDto();
         response.setId(transaccion.getId());
         response.setPresupuesto(transaccion.getPresupuesto());


### PR DESCRIPTION
## Summary
- add a mapper helper component to resolve referenced entities and naturalezamovimiento values by id
- convert request mappers to Spring components that load related entities using provided ids and wire controllers to use them
- align request DTOs with id-based references (including presupuesto origen) and clean unused imports

## Testing
- `mvn test` *(fails: unable to download parent POM from Maven Central due to 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940b57a0704832f8704f073524faeaf)