### PR TITLE
Add dropdown endpoint for presupuestos

### DIFF
--- a/src/main/java/io/github/ahumadamob/plangastos/controller/PresupuestoController.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/controller/PresupuestoController.java
@@ -1,6 +1,7 @@
 package io.github.ahumadamob.plangastos.controller;
 
 import io.github.ahumadamob.plangastos.dto.PresupuestoRequestDto;
+import io.github.ahumadamob.plangastos.dto.PresupuestoDropdownDto;
 import io.github.ahumadamob.plangastos.dto.PresupuestoResponseDto;
 import io.github.ahumadamob.plangastos.dto.common.ApiResponseSuccessDto;
 import io.github.ahumadamob.plangastos.mapper.PresupuestoMapper;
@@ -39,6 +40,14 @@ public class PresupuestoController {
                 .map(mapper::entityToResponse)
                 .toList();
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Listado de presupuestos"));
+    }
+
+    @GetMapping("/dropdown")
+    public ResponseEntity<ApiResponseSuccessDto<List<PresupuestoDropdownDto>>> getDropdown() {
+        List<PresupuestoDropdownDto> data = service.getAllOrderByFechaDesdeDesc().stream()
+                .map(mapper::entityToDropdownDto)
+                .toList();
+        return ResponseEntity.ok(ApiResponseFactory.success(data, "Listado de presupuestos para dropdown"));
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/io/github/ahumadamob/plangastos/dto/PresupuestoDropdownDto.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/dto/PresupuestoDropdownDto.java
@@ -1,0 +1,23 @@
+package io.github.ahumadamob.plangastos.dto;
+
+public class PresupuestoDropdownDto {
+
+    private Long id;
+    private String nombre;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+}

--- a/src/main/java/io/github/ahumadamob/plangastos/mapper/PresupuestoMapper.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/mapper/PresupuestoMapper.java
@@ -2,6 +2,7 @@ package io.github.ahumadamob.plangastos.mapper;
 
 import org.springframework.stereotype.Component;
 
+import io.github.ahumadamob.plangastos.dto.PresupuestoDropdownDto;
 import io.github.ahumadamob.plangastos.dto.PresupuestoRequestDto;
 import io.github.ahumadamob.plangastos.dto.PresupuestoResponseDto;
 import io.github.ahumadamob.plangastos.entity.Presupuesto;
@@ -38,5 +39,12 @@ public class PresupuestoMapper {
         response.setCreatedAt(presupuesto.getCreatedAt());
         response.setUpdatedAt(presupuesto.getUpdatedAt());
         return response;
+    }
+
+    public PresupuestoDropdownDto entityToDropdownDto(Presupuesto presupuesto) {
+        PresupuestoDropdownDto dropdownDto = new PresupuestoDropdownDto();
+        dropdownDto.setId(presupuesto.getId());
+        dropdownDto.setNombre(presupuesto.getNombre());
+        return dropdownDto;
     }
 }

--- a/src/main/java/io/github/ahumadamob/plangastos/repository/PresupuestoRepository.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/repository/PresupuestoRepository.java
@@ -1,5 +1,7 @@
 package io.github.ahumadamob.plangastos.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,6 @@ import io.github.ahumadamob.plangastos.entity.Presupuesto;
 
 @Repository
 public interface PresupuestoRepository extends JpaRepository<Presupuesto, Long> {
+
+    List<Presupuesto> findAllByOrderByFechaDesdeDesc();
 }

--- a/src/main/java/io/github/ahumadamob/plangastos/service/PresupuestoService.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/service/PresupuestoService.java
@@ -7,6 +7,8 @@ public interface PresupuestoService {
 
     List<Presupuesto> getAll();
 
+    List<Presupuesto> getAllOrderByFechaDesdeDesc();
+
     Presupuesto getById(Long id);
 
     Presupuesto create(Presupuesto presupuesto);

--- a/src/main/java/io/github/ahumadamob/plangastos/service/jpa/PresupuestoServiceJpa.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/service/jpa/PresupuestoServiceJpa.java
@@ -21,6 +21,11 @@ public class PresupuestoServiceJpa implements PresupuestoService {
     }
 
     @Override
+    public List<Presupuesto> getAllOrderByFechaDesdeDesc() {
+        return presupuestoRepository.findAllByOrderByFechaDesdeDesc();
+    }
+
+    @Override
     public Presupuesto getById(Long id) {
         return presupuestoRepository.findById(id).orElse(null);
     }


### PR DESCRIPTION
## Summary
- add lightweight DTO for presupuesto dropdown responses
- add repository and service support to fetch budgets ordered by fechaDesde descending
- expose GET /api/v1/presupuesto/dropdown returning id and nombre for each presupuesto

## Testing
- `mvn test` *(fails: unable to resolve parent POM from Maven Central – HTTP 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e758f9a78832fa481eca2c83f911d)