### PR TITLE
Add filtered partida planificada endpoints

### DIFF
--- a/src/main/java/io/github/ahumadamob/plangastos/controller/PartidaPlanificadaController.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/controller/PartidaPlanificadaController.java
@@ -33,6 +33,33 @@ public class PartidaPlanificadaController {
         this.mapper = mapper;
     }
 
+    @GetMapping("/{presupuesto_id}/ingresos")
+    public ResponseEntity<ApiResponseSuccessDto<List<PartidaPlanificadaResponseDto>>> getIngresosByPresupuesto(
+            @PathVariable("presupuesto_id") Long presupuestoId) {
+        List<PartidaPlanificadaResponseDto> data = service.getIngresosByPresupuestoId(presupuestoId).stream()
+                .map(mapper::entityToResponse)
+                .toList();
+        return ResponseEntity.ok(ApiResponseFactory.success(data, "Listado de ingresos planificados por presupuesto"));
+    }
+
+    @GetMapping("/{presupuesto_id}/gastos")
+    public ResponseEntity<ApiResponseSuccessDto<List<PartidaPlanificadaResponseDto>>> getGastosByPresupuesto(
+            @PathVariable("presupuesto_id") Long presupuestoId) {
+        List<PartidaPlanificadaResponseDto> data = service.getGastosByPresupuestoId(presupuestoId).stream()
+                .map(mapper::entityToResponse)
+                .toList();
+        return ResponseEntity.ok(ApiResponseFactory.success(data, "Listado de gastos planificados por presupuesto"));
+    }
+
+    @GetMapping("/{presupuesto_id}/ahorro")
+    public ResponseEntity<ApiResponseSuccessDto<List<PartidaPlanificadaResponseDto>>> getAhorroByPresupuesto(
+            @PathVariable("presupuesto_id") Long presupuestoId) {
+        List<PartidaPlanificadaResponseDto> data = service.getAhorroByPresupuestoId(presupuestoId).stream()
+                .map(mapper::entityToResponse)
+                .toList();
+        return ResponseEntity.ok(ApiResponseFactory.success(data, "Listado de ahorro planificado por presupuesto"));
+    }
+
     @GetMapping
     public ResponseEntity<ApiResponseSuccessDto<List<PartidaPlanificadaResponseDto>>> getAll() {
         List<PartidaPlanificadaResponseDto> data = service.getAll().stream()

--- a/src/main/java/io/github/ahumadamob/plangastos/repository/PartidaPlanificadaRepository.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/repository/PartidaPlanificadaRepository.java
@@ -3,8 +3,13 @@ package io.github.ahumadamob.plangastos.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import io.github.ahumadamob.plangastos.entity.NaturalezaMovimiento;
 import io.github.ahumadamob.plangastos.entity.PartidaPlanificada;
+import java.util.List;
 
 @Repository
 public interface PartidaPlanificadaRepository extends JpaRepository<PartidaPlanificada, Long> {
+
+    List<PartidaPlanificada> findByPresupuestoIdAndRubroNaturaleza(
+            Long presupuestoId, NaturalezaMovimiento naturalezaMovimiento);
 }

--- a/src/main/java/io/github/ahumadamob/plangastos/service/PartidaPlanificadaService.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/service/PartidaPlanificadaService.java
@@ -14,4 +14,10 @@ public interface PartidaPlanificadaService {
     PartidaPlanificada update(Long id, PartidaPlanificada partidaPlanificada);
 
     void delete(Long id);
+
+    List<PartidaPlanificada> getIngresosByPresupuestoId(Long presupuestoId);
+
+    List<PartidaPlanificada> getGastosByPresupuestoId(Long presupuestoId);
+
+    List<PartidaPlanificada> getAhorroByPresupuestoId(Long presupuestoId);
 }

--- a/src/main/java/io/github/ahumadamob/plangastos/service/jpa/PartidaPlanificadaServiceJpa.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/service/jpa/PartidaPlanificadaServiceJpa.java
@@ -1,5 +1,6 @@
 package io.github.ahumadamob.plangastos.service.jpa;
 
+import io.github.ahumadamob.plangastos.entity.NaturalezaMovimiento;
 import io.github.ahumadamob.plangastos.entity.PartidaPlanificada;
 import io.github.ahumadamob.plangastos.repository.PartidaPlanificadaRepository;
 import io.github.ahumadamob.plangastos.service.PartidaPlanificadaService;
@@ -39,5 +40,23 @@ public class PartidaPlanificadaServiceJpa implements PartidaPlanificadaService {
     @Override
     public void delete(Long id) {
         partidaPlanificadaRepository.deleteById(id);
+    }
+
+    @Override
+    public List<PartidaPlanificada> getIngresosByPresupuestoId(Long presupuestoId) {
+        return partidaPlanificadaRepository.findByPresupuestoIdAndRubroNaturaleza(
+                presupuestoId, NaturalezaMovimiento.INGRESO);
+    }
+
+    @Override
+    public List<PartidaPlanificada> getGastosByPresupuestoId(Long presupuestoId) {
+        return partidaPlanificadaRepository.findByPresupuestoIdAndRubroNaturaleza(
+                presupuestoId, NaturalezaMovimiento.GASTO);
+    }
+
+    @Override
+    public List<PartidaPlanificada> getAhorroByPresupuestoId(Long presupuestoId) {
+        return partidaPlanificadaRepository.findByPresupuestoIdAndRubroNaturaleza(
+                presupuestoId, NaturalezaMovimiento.RESERVA_AHORRO);
     }
 }


### PR DESCRIPTION
## Summary
- add repository query to filter partidas planificadas by presupuesto and naturaleza del rubro
- expose service methods and controller endpoints for ingresos, gastos y ahorro
- return mapped responses for each filtered list

## Testing
- mvn -q -DskipTests compile *(fails: Maven could not resolve parent POM due to 403 from central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e8c973528832f89e42c942b73eace)