### PR TITLE
Evitar redundancia de transacciones en respuestas

### DIFF
--- a/src/main/java/io/github/ahumadamob/plangastos/entity/PartidaPlanificada.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/entity/PartidaPlanificada.java
@@ -5,6 +5,8 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -22,6 +24,7 @@ public class PartidaPlanificada extends RegistroPresupuesto {
 
     private LocalDate fechaObjetivo;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "partidaPlanificada", fetch = FetchType.LAZY)
     private List<Transaccion> transacciones = new ArrayList<>();
 


### PR DESCRIPTION
## Summary
- evita que la entidad PartidaPlanificada serialice el arreglo de transacciones, evitando redundancias en las respuestas de transacción

## Testing
- mvnw test *(falla: no se pudo descargar apache-maven por error de red)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ec71991c4832f9da79eb5fa94ed46)