### PR TITLE
Add PATCH endpoint to adjust monto comprometido

### DIFF
--- a/src/main/java/io/github/ahumadamob/plangastos/controller/PartidaPlanificadaController.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/controller/PartidaPlanificadaController.java
@@ -1,5 +1,6 @@
 package io.github.ahumadamob.plangastos.controller;
 
+import io.github.ahumadamob.plangastos.dto.ActualizarMontoComprometidoRequestDto;
 import io.github.ahumadamob.plangastos.dto.PartidaPlanificadaRequestDto;
 import io.github.ahumadamob.plangastos.dto.PartidaPlanificadaResponseDto;
 import io.github.ahumadamob.plangastos.dto.common.ApiResponseSuccessDto;
@@ -8,6 +9,7 @@ import io.github.ahumadamob.plangastos.service.PartidaPlanificadaService;
 import io.github.ahumadamob.plangastos.util.ApiResponseFactory;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -96,6 +98,15 @@ public class PartidaPlanificadaController {
     public ResponseEntity<ApiResponseSuccessDto<PartidaPlanificadaResponseDto>> consolidar(@PathVariable Long id) {
         PartidaPlanificadaResponseDto data = mapper.entityToResponse(service.consolidar(id));
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Partida planificada consolidada"));
+    }
+
+    @PatchMapping("/{id}/monto-comprometido")
+    public ResponseEntity<ApiResponseSuccessDto<PartidaPlanificadaResponseDto>> actualizarMontoComprometido(
+            @PathVariable Long id,
+            @Valid @RequestBody ActualizarMontoComprometidoRequestDto request) {
+        PartidaPlanificadaResponseDto data = mapper.entityToResponse(
+                service.actualizarMontoComprometido(id, request.getMontoComprometido(), request.getPorcentaje()));
+        return ResponseEntity.ok(ApiResponseFactory.success(data, "Monto comprometido actualizado"));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/io/github/ahumadamob/plangastos/dto/ActualizarMontoComprometidoRequestDto.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/dto/ActualizarMontoComprometidoRequestDto.java
@@ -1,0 +1,35 @@
+package io.github.ahumadamob.plangastos.dto;
+
+import java.math.BigDecimal;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.DecimalMin;
+
+public class ActualizarMontoComprometidoRequestDto {
+
+    private BigDecimal montoComprometido;
+
+    @DecimalMin(value = "-100", message = "El porcentaje mínimo permitido es -100")
+    private BigDecimal porcentaje;
+
+    @AssertTrue(message = "Debe especificar montoComprometido o porcentaje, pero no ambos")
+    public boolean isSolicitudValida() {
+        return (montoComprometido != null) ^ (porcentaje != null);
+    }
+
+    public BigDecimal getMontoComprometido() {
+        return montoComprometido;
+    }
+
+    public void setMontoComprometido(BigDecimal montoComprometido) {
+        this.montoComprometido = montoComprometido;
+    }
+
+    public BigDecimal getPorcentaje() {
+        return porcentaje;
+    }
+
+    public void setPorcentaje(BigDecimal porcentaje) {
+        this.porcentaje = porcentaje;
+    }
+}

--- a/src/main/java/io/github/ahumadamob/plangastos/service/PartidaPlanificadaService.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/service/PartidaPlanificadaService.java
@@ -1,6 +1,7 @@
 package io.github.ahumadamob.plangastos.service;
 
 import io.github.ahumadamob.plangastos.entity.PartidaPlanificada;
+import java.math.BigDecimal;
 import java.util.List;
 
 public interface PartidaPlanificadaService {
@@ -22,4 +23,6 @@ public interface PartidaPlanificadaService {
     List<PartidaPlanificada> getAhorroByPresupuestoId(Long presupuestoId);
 
     PartidaPlanificada consolidar(Long id);
+
+    PartidaPlanificada actualizarMontoComprometido(Long id, BigDecimal montoComprometido, BigDecimal porcentaje);
 }

--- a/src/main/java/io/github/ahumadamob/plangastos/service/jpa/PartidaPlanificadaServiceJpa.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/service/jpa/PartidaPlanificadaServiceJpa.java
@@ -7,6 +7,7 @@ import io.github.ahumadamob.plangastos.repository.PartidaPlanificadaRepository;
 import io.github.ahumadamob.plangastos.repository.TransaccionRepository;
 import io.github.ahumadamob.plangastos.service.PartidaPlanificadaService;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
@@ -75,6 +76,25 @@ public class PartidaPlanificadaServiceJpa implements PartidaPlanificadaService {
         BigDecimal montoTotal = transaccionRepository.sumMontoByPartidaPlanificadaId(id);
         partida.setMontoComprometido(montoTotal);
         partida.setConsolidado(Boolean.TRUE);
+
+        return partidaPlanificadaRepository.save(partida);
+    }
+
+    @Override
+    public PartidaPlanificada actualizarMontoComprometido(Long id, BigDecimal montoComprometido, BigDecimal porcentaje) {
+        PartidaPlanificada partida = partidaPlanificadaRepository
+                .findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Partida planificada no encontrada con id " + id));
+
+        BigDecimal montoActual = partida.getMontoComprometido();
+
+        if (porcentaje != null) {
+            BigDecimal ajuste = montoActual.multiply(porcentaje).divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
+            BigDecimal nuevoMonto = montoActual.add(ajuste).setScale(2, RoundingMode.HALF_UP);
+            partida.setMontoComprometido(nuevoMonto);
+        } else {
+            partida.setMontoComprometido(montoComprometido.setScale(2, RoundingMode.HALF_UP));
+        }
 
         return partidaPlanificadaRepository.save(partida);
     }


### PR DESCRIPTION
## Summary
- add a dedicated PATCH endpoint to update monto comprometido with either an absolute value or a percentage
- introduce request validation to accept only one input type and enforce minimum percentage of -100
- compute and persist the adjusted amount with rounding while keeping consolidation logic untouched

## Testing
- mvn test *(fails: unable to resolve spring-boot-starter-parent 4.0.0 because central returned 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ac7e257c0832fb7e1037fd7421669)