### PR TITLE
Agregar endpoint GET /saldos en CuentaFinanciera

### DIFF
--- a/src/main/java/io/github/ahumadamob/plangastos/controller/CuentaFinancieraController.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/controller/CuentaFinancieraController.java
@@ -2,6 +2,7 @@ package io.github.ahumadamob.plangastos.controller;
 
 import io.github.ahumadamob.plangastos.dto.CuentaFinancieraRequestDto;
 import io.github.ahumadamob.plangastos.dto.CuentaFinancieraResponseDto;
+import io.github.ahumadamob.plangastos.dto.CuentaFinancieraSaldoDto;
 import io.github.ahumadamob.plangastos.dto.common.ApiResponseSuccessDto;
 import io.github.ahumadamob.plangastos.mapper.CuentaFinancieraMapper;
 import io.github.ahumadamob.plangastos.service.CuentaFinancieraService;
@@ -39,6 +40,12 @@ public class CuentaFinancieraController {
                 .map(mapper::entityToResponse)
                 .toList();
         return ResponseEntity.ok(ApiResponseFactory.success(data, "Listado de cuentas financieras"));
+    }
+
+    @GetMapping("/saldos")
+    public ResponseEntity<ApiResponseSuccessDto<List<CuentaFinancieraSaldoDto>>> getSaldos() {
+        List<CuentaFinancieraSaldoDto> data = service.getSaldos();
+        return ResponseEntity.ok(ApiResponseFactory.success(data, "Listado de saldos por cuenta financiera"));
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/io/github/ahumadamob/plangastos/dto/CuentaFinancieraSaldoDto.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/dto/CuentaFinancieraSaldoDto.java
@@ -1,0 +1,50 @@
+package io.github.ahumadamob.plangastos.dto;
+
+import java.math.BigDecimal;
+
+public class CuentaFinancieraSaldoDto {
+
+    private Long id;
+    private String nombre;
+    private String divisa;
+    private BigDecimal saldo;
+
+    public CuentaFinancieraSaldoDto(Long id, String nombre, String divisa, BigDecimal saldo) {
+        this.id = id;
+        this.nombre = nombre;
+        this.divisa = divisa;
+        this.saldo = saldo;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getDivisa() {
+        return divisa;
+    }
+
+    public void setDivisa(String divisa) {
+        this.divisa = divisa;
+    }
+
+    public BigDecimal getSaldo() {
+        return saldo;
+    }
+
+    public void setSaldo(BigDecimal saldo) {
+        this.saldo = saldo;
+    }
+}

--- a/src/main/java/io/github/ahumadamob/plangastos/repository/CuentaFinancieraRepository.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/repository/CuentaFinancieraRepository.java
@@ -1,10 +1,39 @@
 package io.github.ahumadamob.plangastos.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
+import io.github.ahumadamob.plangastos.dto.CuentaFinancieraSaldoDto;
 import io.github.ahumadamob.plangastos.entity.CuentaFinanciera;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CuentaFinancieraRepository extends JpaRepository<CuentaFinanciera, Long> {
+
+    @Query(
+            """
+            select new io.github.ahumadamob.plangastos.dto.CuentaFinancieraSaldoDto(
+                c.id,
+                c.nombre,
+                d.codigo,
+                c.saldoInicial + coalesce(sum(
+                    case
+                        when r.naturaleza in (io.github.ahumadamob.plangastos.entity.NaturalezaMovimiento.INGRESO,
+                                              io.github.ahumadamob.plangastos.entity.NaturalezaMovimiento.RESERVA_AHORRO)
+                            then t.monto
+                        when r.naturaleza = io.github.ahumadamob.plangastos.entity.NaturalezaMovimiento.GASTO
+                            then -t.monto
+                        else 0
+                    end
+                ), 0)
+            )
+            from CuentaFinanciera c
+            join c.divisa d
+            left join Transaccion t on t.cuenta.id = c.id
+            left join t.partidaPlanificada pp
+            left join pp.rubro r
+            group by c.id, c.nombre, d.codigo, c.saldoInicial
+            order by c.id
+            """)
+    List<CuentaFinancieraSaldoDto> findAllSaldos();
 }

--- a/src/main/java/io/github/ahumadamob/plangastos/service/CuentaFinancieraService.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/service/CuentaFinancieraService.java
@@ -1,11 +1,14 @@
 package io.github.ahumadamob.plangastos.service;
 
+import io.github.ahumadamob.plangastos.dto.CuentaFinancieraSaldoDto;
 import io.github.ahumadamob.plangastos.entity.CuentaFinanciera;
 import java.util.List;
 
 public interface CuentaFinancieraService {
 
     List<CuentaFinanciera> getAll();
+
+    List<CuentaFinancieraSaldoDto> getSaldos();
 
     CuentaFinanciera getById(Long id);
 

--- a/src/main/java/io/github/ahumadamob/plangastos/service/jpa/CuentaFinancieraServiceJpa.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/service/jpa/CuentaFinancieraServiceJpa.java
@@ -1,5 +1,6 @@
 package io.github.ahumadamob.plangastos.service.jpa;
 
+import io.github.ahumadamob.plangastos.dto.CuentaFinancieraSaldoDto;
 import io.github.ahumadamob.plangastos.entity.CuentaFinanciera;
 import io.github.ahumadamob.plangastos.repository.CuentaFinancieraRepository;
 import io.github.ahumadamob.plangastos.service.CuentaFinancieraService;
@@ -18,6 +19,11 @@ public class CuentaFinancieraServiceJpa implements CuentaFinancieraService {
     @Override
     public List<CuentaFinanciera> getAll() {
         return cuentaFinancieraRepository.findAll();
+    }
+
+    @Override
+    public List<CuentaFinancieraSaldoDto> getSaldos() {
+        return cuentaFinancieraRepository.findAllSaldos();
     }
 
     @Override


### PR DESCRIPTION
### Motivation

- Exponer un endpoint `GET /api/v1/cuenta-financiera/saldos` que devuelva un arreglo de objetos con `id`, `nombre`, `divisa` y `saldo` por cuenta financiera.
- Calcular el `saldo` como `saldoInicial` más la sumatoria de transacciones asociadas a la cuenta, teniendo en cuenta que si la transacción tiene `PartidaPlanificada` → `Rubro` → `NaturalezaMovimiento` entonces `INGRESO` y `RESERVA_AHORRO` se suman y `GASTO` se resta.
- Resolver la agregación en la capa de `repository` mediante consultas JPQL para mantener la lógica eficiente y delegar solo la exposición al `service` y `controller`.

### Description

- Se agregó el DTO `CuentaFinancieraSaldoDto` con los campos `id`, `nombre`, `divisa` y `saldo` para la respuesta específica de este endpoint (`src/main/java/.../dto/CuentaFinancieraSaldoDto.java`).
- Se implementó la consulta JPQL `findAllSaldos()` en `CuentaFinancieraRepository` que realiza `left join` con `Transaccion -> PartidaPlanificada -> Rubro`, usa `case` para aplicar signo según `NaturalezaMovimiento`, `coalesce(sum(...), 0)` para cuentas sin transacciones y devuelve una proyección a `CuentaFinancieraSaldoDto`.
- Se añadió `getSaldos()` en la interfaz `CuentaFinancieraService` y su implementación en `CuentaFinancieraServiceJpa` que delega a `CuentaFinancieraRepository.findAllSaldos()`.
- Se agregó el endpoint en `CuentaFinancieraController` `@GetMapping("/saldos")` que retorna `ApiResponseSuccessDto<List<CuentaFinancieraSaldoDto>>` con el listado de saldos por cuenta.

### Testing

- Se intentó ejecutar `mvn test -q`, pero la ejecución falló por resolución de dependencias externas; `org.springframework.boot:spring-boot-starter-parent:4.0.0` no pudo descargarse desde Maven Central (HTTP 403), por lo que los tests automatizados no pudieron completarse en este entorno.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984dd9967f0832f9120470859bf8a50)