### PR TITLE
Agregar campo `inactivo` en Presupuesto y filtrado en listados y saldos

### DIFF
--- a/src/main/java/io/github/ahumadamob/plangastos/dto/PresupuestoRequestDto.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/dto/PresupuestoRequestDto.java
@@ -1,4 +1,5 @@
 package io.github.ahumadamob.plangastos.dto;
+
 import java.time.LocalDate;
 
 public class PresupuestoRequestDto {
@@ -7,38 +8,54 @@ public class PresupuestoRequestDto {
     private String codigo;
     private LocalDate fechaDesde;
     private LocalDate fechaHasta;
+    private Boolean inactivo;
     private Long presupuestoOrigen_id;
-    
-	public String getNombre() {
-		return nombre;
-	}
-	public void setNombre(String nombre) {
-		this.nombre = nombre;
-	}
-	public String getCodigo() {
-		return codigo;
-	}
-	public void setCodigo(String codigo) {
-		this.codigo = codigo;
-	}
-	public LocalDate getFechaDesde() {
-		return fechaDesde;
-	}
-	public void setFechaDesde(LocalDate fechaDesde) {
-		this.fechaDesde = fechaDesde;
-	}
-	public LocalDate getFechaHasta() {
-		return fechaHasta;
-	}
-	public void setFechaHasta(LocalDate fechaHasta) {
-		this.fechaHasta = fechaHasta;
-	}
-        public Long getPresupuestoOrigen_id() {
-                return presupuestoOrigen_id;
-        }
-        public void setPresupuestoOrigen_id(Long presupuestoOrigen_id) {
-                this.presupuestoOrigen_id = presupuestoOrigen_id;
-        }
 
-    
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getCodigo() {
+        return codigo;
+    }
+
+    public void setCodigo(String codigo) {
+        this.codigo = codigo;
+    }
+
+    public LocalDate getFechaDesde() {
+        return fechaDesde;
+    }
+
+    public void setFechaDesde(LocalDate fechaDesde) {
+        this.fechaDesde = fechaDesde;
+    }
+
+    public LocalDate getFechaHasta() {
+        return fechaHasta;
+    }
+
+    public void setFechaHasta(LocalDate fechaHasta) {
+        this.fechaHasta = fechaHasta;
+    }
+
+    public Boolean getInactivo() {
+        return inactivo;
+    }
+
+    public void setInactivo(Boolean inactivo) {
+        this.inactivo = inactivo;
+    }
+
+    public Long getPresupuestoOrigen_id() {
+        return presupuestoOrigen_id;
+    }
+
+    public void setPresupuestoOrigen_id(Long presupuestoOrigen_id) {
+        this.presupuestoOrigen_id = presupuestoOrigen_id;
+    }
 }

--- a/src/main/java/io/github/ahumadamob/plangastos/dto/PresupuestoResponseDto.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/dto/PresupuestoResponseDto.java
@@ -10,6 +10,7 @@ public class PresupuestoResponseDto {
     private String codigo;
     private LocalDate fechaDesde;
     private LocalDate fechaHasta;
+    private Boolean inactivo;
     private Long presupuestoOrigen_id;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -54,15 +55,23 @@ public class PresupuestoResponseDto {
         this.fechaHasta = fechaHasta;
     }
 
+    public Boolean getInactivo() {
+        return inactivo;
+    }
+
+    public void setInactivo(Boolean inactivo) {
+        this.inactivo = inactivo;
+    }
+
     public Long getPresupuestoOrigen_id() {
-		return presupuestoOrigen_id;
-	}
+        return presupuestoOrigen_id;
+    }
 
-	public void setPresupuestoOrigen_id(Long presupuestoOrigen_id) {
-		this.presupuestoOrigen_id = presupuestoOrigen_id;
-	}
+    public void setPresupuestoOrigen_id(Long presupuestoOrigen_id) {
+        this.presupuestoOrigen_id = presupuestoOrigen_id;
+    }
 
-	public LocalDateTime getCreatedAt() {
+    public LocalDateTime getCreatedAt() {
         return createdAt;
     }
 

--- a/src/main/java/io/github/ahumadamob/plangastos/entity/Presupuesto.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/entity/Presupuesto.java
@@ -25,6 +25,8 @@ public class Presupuesto extends BaseEntity {
 
     private LocalDate fechaHasta;
 
+    private Boolean inactivo;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "presupuesto_origen_id")
     private Presupuesto presupuestoOrigen;
@@ -59,6 +61,14 @@ public class Presupuesto extends BaseEntity {
 
     public void setFechaHasta(LocalDate fechaHasta) {
         this.fechaHasta = fechaHasta;
+    }
+
+    public Boolean getInactivo() {
+        return inactivo;
+    }
+
+    public void setInactivo(Boolean inactivo) {
+        this.inactivo = inactivo;
     }
 
     public Presupuesto getPresupuestoOrigen() {

--- a/src/main/java/io/github/ahumadamob/plangastos/mapper/PresupuestoMapper.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/mapper/PresupuestoMapper.java
@@ -22,6 +22,7 @@ public class PresupuestoMapper {
         presupuesto.setCodigo(request.getCodigo());
         presupuesto.setFechaDesde(request.getFechaDesde());
         presupuesto.setFechaHasta(request.getFechaHasta());
+        presupuesto.setInactivo(request.getInactivo());
         presupuesto.setPresupuestoOrigen(mapperHelper.getPresupuesto(request.getPresupuestoOrigen_id()));
         return presupuesto;
     }
@@ -33,6 +34,7 @@ public class PresupuestoMapper {
         response.setCodigo(presupuesto.getCodigo());
         response.setFechaDesde(presupuesto.getFechaDesde());
         response.setFechaHasta(presupuesto.getFechaHasta());
+        response.setInactivo(presupuesto.getInactivo());
         response.setPresupuestoOrigen_id(presupuesto.getPresupuestoOrigen() == null ? null : presupuesto.getPresupuestoOrigen().getId());
         response.setCreatedAt(presupuesto.getCreatedAt());
         response.setUpdatedAt(presupuesto.getUpdatedAt());

--- a/src/main/java/io/github/ahumadamob/plangastos/repository/CuentaFinancieraRepository.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/repository/CuentaFinancieraRepository.java
@@ -32,6 +32,8 @@ public interface CuentaFinancieraRepository extends JpaRepository<CuentaFinancie
             left join Transaccion t on t.cuenta.id = c.id
             left join t.partidaPlanificada pp
             left join pp.rubro r
+            left join pp.presupuesto p
+            where p.id is null or p.inactivo is null or p.inactivo = false
             group by c.id, c.nombre, d.codigo, c.saldoInicial
             order by c.id
             """)

--- a/src/main/java/io/github/ahumadamob/plangastos/repository/PresupuestoRepository.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/repository/PresupuestoRepository.java
@@ -11,4 +11,8 @@ import io.github.ahumadamob.plangastos.entity.Presupuesto;
 public interface PresupuestoRepository extends JpaRepository<Presupuesto, Long> {
 
     List<Presupuesto> findAllByOrderByFechaDesdeDesc();
+
+    List<Presupuesto> findByInactivoIsNullOrInactivoFalse();
+
+    List<Presupuesto> findByInactivoIsNullOrInactivoFalseOrderByFechaDesdeDesc();
 }

--- a/src/main/java/io/github/ahumadamob/plangastos/service/jpa/PresupuestoServiceJpa.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/service/jpa/PresupuestoServiceJpa.java
@@ -27,12 +27,12 @@ public class PresupuestoServiceJpa implements PresupuestoService {
 
     @Override
     public List<Presupuesto> getAll() {
-        return presupuestoRepository.findAll();
+        return presupuestoRepository.findByInactivoIsNullOrInactivoFalse();
     }
 
     @Override
     public List<Presupuesto> getAllOrderByFechaDesdeDesc() {
-        return presupuestoRepository.findAllByOrderByFechaDesdeDesc();
+        return presupuestoRepository.findByInactivoIsNullOrInactivoFalseOrderByFechaDesdeDesc();
     }
 
     @Override

--- a/src/main/resources/db/migration/V2__add_inactivo_to_presupuestos.sql
+++ b/src/main/resources/db/migration/V2__add_inactivo_to_presupuestos.sql
@@ -1,0 +1,2 @@
+ALTER TABLE presupuestos
+    ADD COLUMN inactivo BOOLEAN NULL;


### PR DESCRIPTION
### Motivation

- Agregar un nuevo campo booleano nullable `inactivo` a la entidad `Presupuesto` para poder marcar presupuestos inactivos y que éstos dejen de aparecer en listados y en cálculos de saldo.
- Cuando `inactivo = true` un `Presupuesto` debe quedar excluido de `PresupuestoController` (en `getAll` y `getDropDown`) y de los cálculos en `CuentaFinancieraController.getSaldos` (excluir transacciones ligadas a `partidaPlanificada` cuyo `presupuesto.inactivo = true`).

### Description

- Se añadió la propiedad `inactivo` (`Boolean`, nullable) con getters/setters en la entidad `Presupuesto` (`src/main/java/io/github/ahumadamob/plangastos/entity/Presupuesto.java`) y se creó la migración Flyway `V2__add_inactivo_to_presupuestos.sql` para añadir la columna en la BD.
- Se incorporó `inactivo` en los DTOs `PresupuestoRequestDto` y `PresupuestoResponseDto` y en el `PresupuestoMapper` para mapear el valor en peticiones y respuestas.
- Se agregaron métodos al repositorio `PresupuestoRepository` (`findByInactivoIsNullOrInactivoFalse` y `findByInactivoIsNullOrInactivoFalseOrderByFechaDesdeDesc`) y se actualizó `PresupuestoServiceJpa` para que `getAll` y `getAllOrderByFechaDesdeDesc` devuelvan solo presupuestos activos (se considera activo cuando `inactivo` es `false` o `null`).
- Se ajustó la consulta JPQL de `CuentaFinancieraRepository.findAllSaldos()` para `left join pp.presupuesto p` y añadir `where p.id is null or p.inactivo is null or p.inactivo = false` de modo que las transacciones vinculadas a partidas con presupuestos inactivos no contribuyan al saldo.

### Testing

- Intenté ejecutar `./mvnw test -q`, pero falló debido a que el wrapper no pudo descargar Maven desde `repo.maven.apache.org` en este entorno.
- Intenté ejecutar `mvn test -q`, pero la ejecución falló porque no se pudieron resolver dependencias del `parent POM` desde Maven Central (HTTP 403), por lo que no se pudieron ejecutar los tests automatizados.
- No se añadieron tests nuevos en este cambio; todas las modificaciones son compatibles con la estructura existente y fueron verificadas a nivel de código en el árbol de fuentes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69889b3945ec832f928b09f2a3b6585c)