### PR TITLE
Eliminar campo `codigo` de la entidad Presupuesto

### DIFF
--- a/src/main/java/io/github/ahumadamob/plangastos/dto/PresupuestoRequestDto.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/dto/PresupuestoRequestDto.java
@@ -5,7 +5,6 @@ import java.time.LocalDate;
 public class PresupuestoRequestDto {
 
     private String nombre;
-    private String codigo;
     private LocalDate fechaDesde;
     private LocalDate fechaHasta;
     private Boolean inactivo;
@@ -19,13 +18,6 @@ public class PresupuestoRequestDto {
         this.nombre = nombre;
     }
 
-    public String getCodigo() {
-        return codigo;
-    }
-
-    public void setCodigo(String codigo) {
-        this.codigo = codigo;
-    }
 
     public LocalDate getFechaDesde() {
         return fechaDesde;

--- a/src/main/java/io/github/ahumadamob/plangastos/dto/PresupuestoResponseDto.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/dto/PresupuestoResponseDto.java
@@ -7,7 +7,6 @@ public class PresupuestoResponseDto {
 
     private Long id;
     private String nombre;
-    private String codigo;
     private LocalDate fechaDesde;
     private LocalDate fechaHasta;
     private Boolean inactivo;
@@ -31,13 +30,6 @@ public class PresupuestoResponseDto {
         this.nombre = nombre;
     }
 
-    public String getCodigo() {
-        return codigo;
-    }
-
-    public void setCodigo(String codigo) {
-        this.codigo = codigo;
-    }
 
     public LocalDate getFechaDesde() {
         return fechaDesde;

--- a/src/main/java/io/github/ahumadamob/plangastos/entity/Presupuesto.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/entity/Presupuesto.java
@@ -18,9 +18,6 @@ public class Presupuesto extends BaseEntity {
     @Column(nullable = false)
     private String nombre;
 
-    @Column(unique = true)
-    private String codigo;
-
     private LocalDate fechaDesde;
 
     private LocalDate fechaHasta;
@@ -37,14 +34,6 @@ public class Presupuesto extends BaseEntity {
 
     public void setNombre(String nombre) {
         this.nombre = nombre;
-    }
-
-    public String getCodigo() {
-        return codigo;
-    }
-
-    public void setCodigo(String codigo) {
-        this.codigo = codigo;
     }
 
     public LocalDate getFechaDesde() {

--- a/src/main/java/io/github/ahumadamob/plangastos/mapper/PresupuestoMapper.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/mapper/PresupuestoMapper.java
@@ -19,7 +19,6 @@ public class PresupuestoMapper {
     public Presupuesto requestToEntity(PresupuestoRequestDto request) {
         Presupuesto presupuesto = new Presupuesto();
         presupuesto.setNombre(request.getNombre());
-        presupuesto.setCodigo(request.getCodigo());
         presupuesto.setFechaDesde(request.getFechaDesde());
         presupuesto.setFechaHasta(request.getFechaHasta());
         presupuesto.setInactivo(request.getInactivo());
@@ -31,7 +30,6 @@ public class PresupuestoMapper {
         PresupuestoResponseDto response = new PresupuestoResponseDto();
         response.setId(presupuesto.getId());
         response.setNombre(presupuesto.getNombre());
-        response.setCodigo(presupuesto.getCodigo());
         response.setFechaDesde(presupuesto.getFechaDesde());
         response.setFechaHasta(presupuesto.getFechaHasta());
         response.setInactivo(presupuesto.getInactivo());

--- a/src/main/resources/db/migration/V3__drop_codigo_from_presupuestos.sql
+++ b/src/main/resources/db/migration/V3__drop_codigo_from_presupuestos.sql
@@ -1,0 +1,2 @@
+ALTER TABLE presupuestos
+    DROP COLUMN IF EXISTS codigo;


### PR DESCRIPTION
### Motivation
- Quitar el atributo `codigo` de la entidad `Presupuesto` para que deje de exponerse y consumirse por la API y por los DTOs.
- Refactorizar el mapeo y la migración de base de datos para mantener coherencia entre entidad, DTOs y esquema SQL.

### Description
- Se eliminó el atributo `codigo` (y sus getters/setters) de `src/main/java/io/github/ahumadamob/plangastos/entity/Presupuesto.java`.
- Se removió `codigo` de `PresupuestoRequestDto` y `PresupuestoResponseDto` para que no aparezca en los payloads REST ni en el OpenAPI generado.`
- Se actualizó `PresupuestoMapper` para dejar de mapear `codigo` desde/hacia los DTOs.
- Se agregó la migración Flyway `src/main/resources/db/migration/V3__drop_codigo_from_presupuestos.sql` que elimina la columna `codigo` de la tabla `presupuestos`.

### Testing
- Ejecuté `./mvnw -q test` pero falló por descarga del wrapper / Maven en este entorno (error al obtener `apache-maven-3.9.11-bin.zip`).
- Ejecuté `mvn -q test` y falló por resolución de dependencias remotas (HTTP 403 al acceder a Maven Central para `spring-boot-starter-parent:4.0.0`).
- Debido a las restricciones de acceso al repositorio remoto, no fue posible ejecutar la suite de tests automatizados en este entorno; los cambios se limitaron a modificaciones del código y la migración SQL.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990baaba8bc832f9210801489e5dcde)