### PR TITLE
Forzar booleanos NOT NULL y defaults en entidades y mappers

### DIFF
--- a/src/main/java/io/github/ahumadamob/plangastos/entity/CuentaFinanciera.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/entity/CuentaFinanciera.java
@@ -41,7 +41,7 @@ public class CuentaFinanciera extends BaseEntity {
 
     @NotNull
     @Column(nullable = false)
-    private Boolean activo;
+    private boolean activo = false;
 
     public Usuario getUsuario() {
         return usuario;
@@ -83,11 +83,11 @@ public class CuentaFinanciera extends BaseEntity {
         this.saldoInicial = saldoInicial;
     }
 
-    public Boolean getActivo() {
+    public boolean getActivo() {
         return activo;
     }
 
-    public void setActivo(Boolean activo) {
+    public void setActivo(boolean activo) {
         this.activo = activo;
     }
 }

--- a/src/main/java/io/github/ahumadamob/plangastos/entity/PartidaPlanificada.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/entity/PartidaPlanificada.java
@@ -28,7 +28,8 @@ public class PartidaPlanificada extends RegistroPresupuesto {
 
     private LocalDate fechaObjetivo;
 
-    private Boolean consolidado = Boolean.FALSE;
+    @Column(nullable = false)
+    private boolean consolidado = false;
 
     @Positive
     // Se mapea a la columna "cuota" para mantener la nomenclatura en BD.
@@ -69,11 +70,11 @@ public class PartidaPlanificada extends RegistroPresupuesto {
         this.fechaObjetivo = fechaObjetivo;
     }
 
-    public Boolean getConsolidado() {
+    public boolean getConsolidado() {
         return consolidado;
     }
 
-    public void setConsolidado(Boolean consolidado) {
+    public void setConsolidado(boolean consolidado) {
         this.consolidado = consolidado;
     }
 

--- a/src/main/java/io/github/ahumadamob/plangastos/entity/Presupuesto.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/entity/Presupuesto.java
@@ -25,7 +25,8 @@ public class Presupuesto extends BaseEntity {
 
     private LocalDate fechaHasta;
 
-    private Boolean inactivo;
+    @Column(nullable = false)
+    private boolean inactivo = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "presupuesto_origen_id")
@@ -55,11 +56,11 @@ public class Presupuesto extends BaseEntity {
         this.fechaHasta = fechaHasta;
     }
 
-    public Boolean getInactivo() {
+    public boolean getInactivo() {
         return inactivo;
     }
 
-    public void setInactivo(Boolean inactivo) {
+    public void setInactivo(boolean inactivo) {
         this.inactivo = inactivo;
     }
 

--- a/src/main/java/io/github/ahumadamob/plangastos/entity/Rubro.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/entity/Rubro.java
@@ -37,7 +37,7 @@ public class Rubro extends BaseEntity {
 
     @NotNull
     @Column(nullable = false)
-    private Boolean activo;
+    private boolean activo = false;
 
     public Usuario getUsuario() {
         return usuario;
@@ -71,11 +71,11 @@ public class Rubro extends BaseEntity {
         this.parent = parent;
     }
 
-    public Boolean getActivo() {
+    public boolean getActivo() {
         return activo;
     }
 
-    public void setActivo(Boolean activo) {
+    public void setActivo(boolean activo) {
         this.activo = activo;
     }
 

--- a/src/main/java/io/github/ahumadamob/plangastos/mapper/CuentaFinancieraMapper.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/mapper/CuentaFinancieraMapper.java
@@ -23,7 +23,7 @@ public class CuentaFinancieraMapper {
         cuentaFinanciera.setNombre(request.getNombre());
         cuentaFinanciera.setTipo(request.getTipo());
         cuentaFinanciera.setSaldoInicial(request.getSaldoInicial());
-        cuentaFinanciera.setActivo(request.getActivo());
+        cuentaFinanciera.setActivo(Boolean.TRUE.equals(request.getActivo()));
         return cuentaFinanciera;
     }
 

--- a/src/main/java/io/github/ahumadamob/plangastos/mapper/PresupuestoMapper.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/mapper/PresupuestoMapper.java
@@ -21,7 +21,7 @@ public class PresupuestoMapper {
         presupuesto.setNombre(request.getNombre());
         presupuesto.setFechaDesde(request.getFechaDesde());
         presupuesto.setFechaHasta(request.getFechaHasta());
-        presupuesto.setInactivo(request.getInactivo());
+        presupuesto.setInactivo(Boolean.TRUE.equals(request.getInactivo()));
         presupuesto.setPresupuestoOrigen(mapperHelper.getPresupuesto(request.getPresupuestoOrigen_id()));
         return presupuesto;
     }

--- a/src/main/java/io/github/ahumadamob/plangastos/mapper/RubroMapper.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/mapper/RubroMapper.java
@@ -19,7 +19,7 @@ public class RubroMapper {
         Rubro rubro = new Rubro();
         rubro.setNaturaleza(mapperHelper.getNaturalezaMovimiento(request.getNaturalezaMovimiento_id()));
         rubro.setNombre(request.getNombre());
-        rubro.setActivo(request.getActivo());
+        rubro.setActivo(Boolean.TRUE.equals(request.getActivo()));
         return rubro;
     }
 

--- a/src/main/java/io/github/ahumadamob/plangastos/repository/PresupuestoRepository.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/repository/PresupuestoRepository.java
@@ -12,7 +12,7 @@ public interface PresupuestoRepository extends JpaRepository<Presupuesto, Long> 
 
     List<Presupuesto> findAllByOrderByFechaDesdeDesc();
 
-    List<Presupuesto> findByInactivoIsNullOrInactivoFalse();
+    List<Presupuesto> findByInactivoFalse();
 
-    List<Presupuesto> findByInactivoIsNullOrInactivoFalseOrderByFechaDesdeDesc();
+    List<Presupuesto> findByInactivoFalseOrderByFechaDesdeDesc();
 }

--- a/src/main/java/io/github/ahumadamob/plangastos/service/jpa/PartidaPlanificadaServiceJpa.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/service/jpa/PartidaPlanificadaServiceJpa.java
@@ -98,7 +98,7 @@ public class PartidaPlanificadaServiceJpa implements PartidaPlanificadaService {
 
         BigDecimal montoTotal = transaccionRepository.sumMontoByPartidaPlanificadaId(id);
         partida.setMontoComprometido(montoTotal);
-        partida.setConsolidado(Boolean.TRUE);
+        partida.setConsolidado(true);
 
         Long partidaOrigenId = partida.getPartidaOrigen() != null ? partida.getPartidaOrigen().getId() : partida.getId();
         List<PartidaPlanificada> partidasRelacionadas =

--- a/src/main/java/io/github/ahumadamob/plangastos/service/jpa/PresupuestoServiceJpa.java
+++ b/src/main/java/io/github/ahumadamob/plangastos/service/jpa/PresupuestoServiceJpa.java
@@ -30,12 +30,12 @@ public class PresupuestoServiceJpa implements PresupuestoService {
 
     @Override
     public List<Presupuesto> getAll() {
-        return presupuestoRepository.findByInactivoIsNullOrInactivoFalse();
+        return presupuestoRepository.findByInactivoFalse();
     }
 
     @Override
     public List<Presupuesto> getAllOrderByFechaDesdeDesc() {
-        return presupuestoRepository.findByInactivoIsNullOrInactivoFalseOrderByFechaDesdeDesc();
+        return presupuestoRepository.findByInactivoFalseOrderByFechaDesdeDesc();
     }
 
     @Override
@@ -124,7 +124,7 @@ public class PresupuestoServiceJpa implements PresupuestoService {
         partidaNueva.setDescripcion(partidaOrigen.getDescripcion());
         partidaNueva.setMontoComprometido(partidaOrigen.getMontoComprometido());
         partidaNueva.setPartidaOrigen(partidaOrigen);
-        partidaNueva.setConsolidado(Boolean.FALSE);
+        partidaNueva.setConsolidado(false);
         partidaNueva.setCantidadCuotas(partidaOrigen.getCantidadCuotas());
         partidaNueva.setFechaObjetivo(ajustarFechaObjetivo(
                 partidaOrigen.getFechaObjetivo(), mesesDiferencia));

--- a/src/main/resources/db/migration/V4__enforce_boolean_states_not_null.sql
+++ b/src/main/resources/db/migration/V4__enforce_boolean_states_not_null.sql
@@ -1,0 +1,27 @@
+UPDATE presupuestos
+SET inactivo = FALSE
+WHERE inactivo IS NULL;
+
+ALTER TABLE presupuestos
+    MODIFY COLUMN inactivo BOOLEAN NOT NULL;
+
+UPDATE partidas_planificadas
+SET consolidado = FALSE
+WHERE consolidado IS NULL;
+
+ALTER TABLE partidas_planificadas
+    MODIFY COLUMN consolidado BOOLEAN NOT NULL;
+
+UPDATE rubros
+SET activo = FALSE
+WHERE activo IS NULL;
+
+ALTER TABLE rubros
+    MODIFY COLUMN activo BOOLEAN NOT NULL;
+
+UPDATE cuentas_financieras
+SET activo = FALSE
+WHERE activo IS NULL;
+
+ALTER TABLE cuentas_financieras
+    MODIFY COLUMN activo BOOLEAN NOT NULL;

--- a/src/test/java/io/github/ahumadamob/plangastos/mapper/BooleanStateMapperTest.java
+++ b/src/test/java/io/github/ahumadamob/plangastos/mapper/BooleanStateMapperTest.java
@@ -1,0 +1,59 @@
+package io.github.ahumadamob.plangastos.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.github.ahumadamob.plangastos.dto.CuentaFinancieraRequestDto;
+import io.github.ahumadamob.plangastos.dto.PresupuestoRequestDto;
+import io.github.ahumadamob.plangastos.dto.RubroRequestDto;
+import io.github.ahumadamob.plangastos.entity.Divisa;
+import io.github.ahumadamob.plangastos.entity.NaturalezaMovimiento;
+import io.github.ahumadamob.plangastos.entity.TipoCuenta;
+import io.github.ahumadamob.plangastos.entity.Usuario;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BooleanStateMapperTest {
+
+    @Mock
+    private MapperHelper mapperHelper;
+
+    @Test
+    void presupuestoMapper_DebeDefaultearInactivoEnFalse_CuandoNoVieneEnRequest() {
+        PresupuestoMapper mapper = new PresupuestoMapper(mapperHelper);
+        PresupuestoRequestDto request = new PresupuestoRequestDto();
+        request.setNombre("Presupuesto");
+
+        assertThat(mapper.requestToEntity(request).getInactivo()).isFalse();
+    }
+
+    @Test
+    void rubroMapper_DebeDefaultearActivoEnFalse_CuandoNoVieneEnRequest() {
+        RubroMapper mapper = new RubroMapper(mapperHelper);
+        RubroRequestDto request = new RubroRequestDto();
+        request.setNombre("Rubro");
+        request.setNaturalezaMovimiento_id(1L);
+
+        when(mapperHelper.getNaturalezaMovimiento(1L)).thenReturn(NaturalezaMovimiento.GASTO);
+
+        assertThat(mapper.requestToEntity(request).getActivo()).isFalse();
+    }
+
+    @Test
+    void cuentaFinancieraMapper_DebeDefaultearActivoEnFalse_CuandoNoVieneEnRequest() {
+        CuentaFinancieraMapper mapper = new CuentaFinancieraMapper(mapperHelper);
+        CuentaFinancieraRequestDto request = new CuentaFinancieraRequestDto();
+        request.setUsuario_id(1L);
+        request.setDivisa_id(2L);
+        request.setNombre("Cuenta");
+        request.setTipo(TipoCuenta.EFECTIVO);
+
+        when(mapperHelper.getUsuario(1L)).thenReturn(new Usuario());
+        when(mapperHelper.getDivisa(2L)).thenReturn(new Divisa());
+
+        assertThat(mapper.requestToEntity(request).getActivo()).isFalse();
+    }
+}

--- a/src/test/java/io/github/ahumadamob/plangastos/service/jpa/PartidaPlanificadaServiceJpaTest.java
+++ b/src/test/java/io/github/ahumadamob/plangastos/service/jpa/PartidaPlanificadaServiceJpaTest.java
@@ -264,4 +264,15 @@ class PartidaPlanificadaServiceJpaTest {
         assertThat(resultado).isSameAs(partida);
     }
 
+    @Test
+    void create_DebePersistirConsolidadoEnFalsePorDefecto() {
+        PartidaPlanificada partida = new PartidaPlanificada();
+
+        when(partidaPlanificadaRepository.save(partida)).thenReturn(partida);
+
+        PartidaPlanificada resultado = partidaPlanificadaServiceJpa.create(partida);
+
+        assertThat(resultado.getConsolidado()).isFalse();
+    }
+
 }

--- a/src/test/java/io/github/ahumadamob/plangastos/service/jpa/PresupuestoServiceJpaTest.java
+++ b/src/test/java/io/github/ahumadamob/plangastos/service/jpa/PresupuestoServiceJpaTest.java
@@ -86,6 +86,18 @@ class PresupuestoServiceJpaTest {
         verify(presupuestoRepository, never()).save(any());
     }
 
+
+    @Test
+    void create_DebePersistirInactivoEnFalsePorDefecto() {
+        Presupuesto presupuesto = new Presupuesto();
+
+        when(presupuestoRepository.save(presupuesto)).thenReturn(presupuesto);
+
+        Presupuesto resultado = presupuestoServiceJpa.create(presupuesto);
+
+        assertThat(resultado.getInactivo()).isFalse();
+    }
+
     @Test
     void create_WhenNoPresupuestoOrigen_ShouldNotCopiarPartidas() {
         Presupuesto presupuesto = new Presupuesto();


### PR DESCRIPTION
### Motivation
- Eliminar ambigüedad entre `NULL` y `false` en estados booleanos para evitar lógica condicional dispersa y comportamientos inconsistentes en consultas y servicios.
- Asegurar que la API respete un default de negocio cuando el cliente omite campos booleanos en requests.

### Description
- Convertí campos envoltorio `Boolean` a primitivos `boolean` con `@Column(nullable = false)` y valor por defecto `false` en las entidades `Presupuesto.inactivo`, `PartidaPlanificada.consolidado`, `Rubro.activo` y `CuentaFinanciera.activo` (ej. `src/main/java/.../Presupuesto.java`).
- Actualicé los mappers para aplicar el default de negocio cuando el request omite el campo usando `Boolean.TRUE.equals(request.getXxx())`, en `PresupuestoMapper`, `RubroMapper` y `CuentaFinancieraMapper`.
- Ajusté consultas y servicios que asumían `NULL` en `inactivo` a la nueva semántica no-null reemplazando `findByInactivoIsNullOrInactivoFalse()` por `findByInactivoFalse()` y dejando consistente el uso de primitivos en `PresupuestoServiceJpa` y `PartidaPlanificadaServiceJpa`.
- Añadí la migración Flyway `src/main/resources/db/migration/V4__enforce_boolean_states_not_null.sql` que hace backfill `NULL -> FALSE` y aplica `ALTER ... NOT NULL` sobre las columnas afectadas.
- Añadí tests unitarios para validar el comportamiento por defecto: `src/test/java/.../mapper/BooleanStateMapperTest.java` y pequeñas pruebas en `PresupuestoServiceJpaTest` y `PartidaPlanificadaServiceJpaTest` que verifican que los estados se persisten como `false` cuando no se envían.

### Testing
- Se agregó y ejecutó localmente la suite de tests enfocada con `mvn -q -Dtest=BooleanStateMapperTest,PresupuestoServiceJpaTest,PartidaPlanificadaServiceJpaTest test` para validar mappers y servicios, pero la ejecución quedó bloqueada por resolución de dependencias del parent Spring Boot POM en este entorno (error HTTP 403 al acceder a Maven Central).
- Los tests nuevos están incluidos en el commit y pueden ejecutarse en CI/entorno con acceso a Maven Central; la intención es que pasen una vez resueltas las dependencias externas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993492ded30832f8cbedd5742756cc0)